### PR TITLE
fix: links do readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Quer fazer parte desse projeto? Clique [AQUI](CONTRIBUTING.md) e leia como contr
 
 Esse projeto está sob licença. Veja o arquivo [LICENÇA](LICENSE.md) para mais detalhes.
 
-[⬆ Voltar ao topo](#nome-do-projeto)<br>
+[⬆ Voltar ao topo](#search.Github)<br>

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Quer fazer parte desse projeto? Clique [AQUI](CONTRIBUTING.md) e leia como contr
 
 Esse projeto está sob licença. Veja o arquivo [LICENÇA](LICENSE.md) para mais detalhes.
 
-[⬆ Voltar ao topo](#search.Github)<br>
+[⬆ Voltar ao topo](#searchgithub)<br>


### PR DESCRIPTION
Fui concertar alguns links quebrados, deparei com a ausência dos arquivos `LICENSE.md` e `CONTRIBUTING.md`; então preparei apenas o link da linha 77. Posso sugerir um arquivo `CONTRIBUTING.md` numa próxima PR. 😄 🚀 